### PR TITLE
fix flag size

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -203,7 +203,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
                 if ($showFlag) {
                     $icon = imagecreatefrompng(PIWIK_INCLUDE_PATH . DIRECTORY_SEPARATOR . $country['icon']);
-                    imagecopy($im, $icon, 5 + ($currentCol) * $colWidth, (5 + $currentRow * 25), 0, 0, 16, 12);
+                    imagecopyresampled($im, $icon, 5 + ($currentCol) * $colWidth, (5 + $currentRow * 25), 0, 0, 16, 12,64,48);
                     imagedestroy($icon);
                 }
 


### PR DESCRIPTION
With the new flags this plugin was broken as it assumes a fixed size.
![index](https://cloud.githubusercontent.com/assets/6266037/25124313/9ff163c8-242b-11e7-91e8-d72092f8cf2e.png)

This is just a quick fix by resizing the icons to the target size.
![index 1](https://cloud.githubusercontent.com/assets/6266037/25124314/9ff620a2-242b-11e7-8025-29a51843147f.png)
